### PR TITLE
[setting] prettier の設定

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,8 @@
         "plugin:import/warnings", // 追加
         "plugin:import/typescript", // 追加
         "plugin:@typescript-eslint/recommended", // 追加
-        "plugin:@typescript-eslint/recommended-requiring-type-checking" // 追加
+        "plugin:@typescript-eslint/recommended-requiring-type-checking", // 追加
+        "prettier"
     ],
     "parser": "@typescript-eslint/parser",
     "parserOptions": {

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,4 @@
+# Ignore artifacts:
+build
+coverage
+*.svg

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+    "trailingComma": "es5",
+    "tabWidth": 2,
+    "semi": false,
+    "singleQuote": true
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,10 +26,12 @@
         "@typescript-eslint/parser": "^5.10.1",
         "eslint": "^8.7.0",
         "eslint-config-airbnb": "^19.0.4",
+        "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.28.0",
-        "eslint-plugin-react-hooks": "^4.3.0"
+        "eslint-plugin-react-hooks": "^4.3.0",
+        "prettier": "2.5.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -6450,6 +6452,18 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-config-react-app": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.0.tgz",
@@ -12644,6 +12658,18 @@
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin-prettier.js"
+      },
+      "engines": {
+        "node": ">=10.13.0"
       }
     },
     "node_modules/pretty-bytes": {
@@ -20600,6 +20626,13 @@
         }
       }
     },
+    "eslint-config-prettier": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
+      "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-config-react-app": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-react-app/-/eslint-config-react-app-7.0.0.tgz",
@@ -24852,6 +24885,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="
+    },
+    "prettier": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
     },
     "pretty-bytes": {
       "version": "5.6.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,10 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint:eslint": "eslint --ext .jsx,.js,.tsx,.ts src/",
-    "fix:eslint": "eslint --fix --ext .js,.jsx,.ts,.tsx src/"
+    "fix:eslint": "eslint --fix --ext .js,.jsx,.ts,.tsx src/",
+    "fmt:write": "prettier --write src/**/*",
+    "fmt:check": "prettier --check src/**/*",
+    "fmt": "npm run fmt:write && npm run lint:eslint"
   },
   "browserslist": {
     "production": [
@@ -41,9 +44,11 @@
     "@typescript-eslint/parser": "^5.10.1",
     "eslint": "^8.7.0",
     "eslint-config-airbnb": "^19.0.4",
+    "eslint-config-prettier": "^8.3.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.28.0",
-    "eslint-plugin-react-hooks": "^4.3.0"
+    "eslint-plugin-react-hooks": "^4.3.0",
+    "prettier": "2.5.1"
   }
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import App from './App'
 
 test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});
+  render(<App />)
+  const linkElement = screen.getByText(/learn react/i)
+  expect(linkElement).toBeInTheDocument()
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import logo from './logo.svg';
-import './App.css';
-import Text from './components/atoms/Text';
+import logo from './logo.svg'
+import './App.css'
+import Text from './components/atoms/Text'
 
 const App: React.FC = () => {
   return (
@@ -8,11 +8,7 @@ const App: React.FC = () => {
       <header className="App-header">
         <img src={logo} className="App-logo" alt="logo" />
         <p>
-          Edit
-          {' '}
-          <code>src/App.tsx</code>
-          {' '}
-          and save to reload.
+          Edit <code>src/App.tsx</code> and save to reload.
         </p>
         <a
           className="App-link"
@@ -25,7 +21,7 @@ const App: React.FC = () => {
       </header>
       <Text text="hello" />
     </div>
-  );
-};
+  )
+}
 
-export default App;
+export default App

--- a/src/components/atoms/Text.tsx
+++ b/src/components/atoms/Text.tsx
@@ -3,12 +3,8 @@ type TextPropsType = {
 }
 
 const Text: React.FC<TextPropsType> = (props) => {
-  const { text } = props;
-  return (
-    <div>
-      {text}
-    </div>
-  );
-};
+  const { text } = props
+  return <div>{text}</div>
+}
 
-export default Text;
+export default Text

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,17 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
+import React from 'react'
+import ReactDOM from 'react-dom'
+import './index.css'
+import App from './App'
+import reportWebVitals from './reportWebVitals'
 
 ReactDOM.render(
   <React.StrictMode>
     <App />
   </React.StrictMode>,
-  document.getElementById('root'),
-);
+  document.getElementById('root')
+)
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
-reportWebVitals();
+reportWebVitals()

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,19 +1,19 @@
-import { ReportHandler } from 'web-vitals';
+import { ReportHandler } from 'web-vitals'
 
 const reportWebVitals = (onPerfEntry?: ReportHandler) => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
-    import('web-vitals').then(({
-      getCLS, getFID, getFCP, getLCP, getTTFB,
-    }) => {
-      getCLS(onPerfEntry);
-      getFID(onPerfEntry);
-      getFCP(onPerfEntry);
-      getLCP(onPerfEntry);
-      getTTFB(onPerfEntry);
-    }).catch((e) => {
-      console.log(e);// eslint-disable-line no-console
-    });
+    import('web-vitals')
+      .then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
+        getCLS(onPerfEntry)
+        getFID(onPerfEntry)
+        getFCP(onPerfEntry)
+        getLCP(onPerfEntry)
+        getTTFB(onPerfEntry)
+      })
+      .catch((e) => {
+        console.log(e) // eslint-disable-line no-console
+      })
   }
-};
+}
 
-export default reportWebVitals;
+export default reportWebVitals

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -2,4 +2,4 @@
 // allows you to do things like:
 // expect(element).toHaveTextContent(/react/i)
 // learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom'


### PR DESCRIPTION
# 概要
コードにフォーマットツールprettierを追加

# 目的
コーディングスタイルを統一するため

# 追加パッケージ
- eslint-config-prettier: eslintとprettierの設定のかぶりを除くためのパッケージ
- prettier: フォーマットツールprettier本体

# 追加ファイル
- .prettierignore: フォーマット対象外を設定するファイル
- .prettierrc.json: 設定ファイル

# 変更ファイル
- package.json
- .eslintrc.json