### PR TITLE
[setting] baseUrl を使った import の設定

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -81,6 +81,9 @@
                     ".ts",
                     ".tsx"
                 ]
+            },
+            "typescript": {
+                "project": "src"
             }
         }
     }

--- a/README.md
+++ b/README.md
@@ -20,3 +20,24 @@ run prettier check code format for all file in /src folder
 
 ## fmt
 format all code in /src folder
+
+# npm packages
+## eslint-import-resolver-typescript
+This package resolve import problem about tsconfig for baseUrl.
+This package need to add two below setting.
+
+In eslintrc
+```
+settings: {
+    'import/resolver': {
+        typescript: {},
+    },
+},
+```
+
+In jest.config
+```
+moduleDirectories: [
+    "src"
+],
+```

--- a/__test__/App.test.tsx
+++ b/__test__/App.test.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react'
-import App from '../src/App'
+import App from 'App'
 
 test('renders learn react link', () => {
   render(<App />)

--- a/__test__/components/atoms/Button.test.tsx
+++ b/__test__/components/atoms/Button.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import Button, { ButtonPropsType } from '../../../src/components/atoms/Button'
+import Button, { ButtonPropsType } from 'components/atoms/Button'
 
 describe("button test", () => {
     test("click check test", () => {

--- a/__test__/components/atoms/Text.test.tsx
+++ b/__test__/components/atoms/Text.test.tsx
@@ -1,5 +1,5 @@
 import { render } from '@testing-library/react'
-import Text from '../../../src/components/atoms/Text'
+import Text from 'components/atoms/Text'
 
 describe('Textコンポーネントテスト', () => {
   test('日本語文字が表示されるか', () => {

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -70,9 +70,10 @@ export default {
   // maxWorkers: "50%",
 
   // An array of directory names to be searched recursively up from the requiring module's location
-  // moduleDirectories: [
-  //   "node_modules"
-  // ],
+  moduleDirectories: [
+    "node_modules",
+    "src"
+  ],
 
   // An array of file extensions your modules use
   moduleFileExtensions: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "eslint": "^8.7.0",
         "eslint-config-airbnb": "^19.0.4",
         "eslint-config-prettier": "^8.3.0",
+        "eslint-import-resolver-typescript": "^2.5.0",
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsx-a11y": "^6.5.1",
         "eslint-plugin-react": "^7.28.0",
@@ -6598,6 +6599,26 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.5.0.tgz",
+      "integrity": "sha512-qZ6e5CFr+I7K4VVhQu3M/9xGv9/YmwsEXrsm3nimw8vWaVHRDrQRp26BgCypTxBp3vUp4o5aVEJRiy0F2DFddQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "^4.3.1",
+        "glob": "^7.1.7",
+        "is-glob": "^4.0.1",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {
@@ -21042,6 +21063,19 @@
             "ms": "^2.1.1"
           }
         }
+      }
+    },
+    "eslint-import-resolver-typescript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-2.5.0.tgz",
+      "integrity": "sha512-qZ6e5CFr+I7K4VVhQu3M/9xGv9/YmwsEXrsm3nimw8vWaVHRDrQRp26BgCypTxBp3vUp4o5aVEJRiy0F2DFddQ==",
+      "dev": true,
+      "requires": {
+        "debug": "^4.3.1",
+        "glob": "^7.1.7",
+        "is-glob": "^4.0.1",
+        "resolve": "^1.20.0",
+        "tsconfig-paths": "^3.9.0"
       }
     },
     "eslint-module-utils": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "eslint": "^8.7.0",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-config-prettier": "^8.3.0",
+    "eslint-import-resolver-typescript": "^2.5.0",
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsx-a11y": "^6.5.1",
     "eslint-plugin-react": "^7.28.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,6 @@
-import logo from './logo.svg'
-import './App.css'
-import Text from './components/atoms/Text'
+import logo from 'logo.svg'
+import 'App.css'
+import Text from 'components/atoms/Text'
 
 const App: React.FC = () => {
   return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
-import './index.css'
-import App from './App'
+import 'index.css'
+import App from 'App'
 import reportWebVitals from './reportWebVitals'
 
 ReactDOM.render(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
       "esnext"
     ],
     "allowJs": true,
+    "baseUrl": "src/",
     "skipLibCheck": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
@@ -21,6 +22,7 @@
     "jsx": "react-jsx"
   },
   "include": [
-    "src"
+    "src",
+    "__test__"
   ]
 }


### PR DESCRIPTION
# 概要
baseUrl を使った import ができるように設定を変更した

# 目的
import が長くならないよう にするため

# 追加パッケージ
- eslint-import-resolver-typescript

# 追加ファイル
なし

# 変更ファイル
- package.json
- .eslintrc.json
- jest.config.ts
- tsconfig.json
- package-lock.json
- README.md
- __test__/**
- src/**